### PR TITLE
Feature/si 2679 add vehicletokenid to status payload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DIMO-Network/privacy-processor
 go 1.22
 
 require (
-	github.com/DIMO-Network/shared v0.10.17
+	github.com/DIMO-Network/shared v0.10.20
 	github.com/IBM/sarama v1.41.3
 	github.com/burdiyan/kafkautil v0.0.0-20240215092415-7e6d3d0fc870
 	github.com/lovoo/goka v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/DIMO-Network/shared v0.10.17 h1:PRSuPU/Aa17k70bz8VeCV6SzLsNr/9/TG5LkrB1SMuY=
-github.com/DIMO-Network/shared v0.10.17/go.mod h1:LDNCMzOGA+MqXtHbvRDFS/1kl8sHMQgxAS8fFh4GKJA=
+github.com/DIMO-Network/shared v0.10.20 h1:F681r8hDigtQNEFQJnWgW7/P6Y5hPElmfM+OKqG2CFc=
+github.com/DIMO-Network/shared v0.10.20/go.mod h1:LDNCMzOGA+MqXtHbvRDFS/1kl8sHMQgxAS8fFh4GKJA=
 github.com/IBM/sarama v1.41.3 h1:MWBEJ12vHC8coMjdEXFq/6ftO6DUZnQlFYcxtOJFa7c=
 github.com/IBM/sarama v1.41.3/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=

--- a/internal/processors/privacy_v2_test.go
+++ b/internal/processors/privacy_v2_test.go
@@ -3,11 +3,11 @@ package processors
 import (
 	"context"
 	"encoding/json"
-	"github.com/DIMO-Network/shared"
 	"os"
 	"strconv"
 	"testing"
 
+	"github.com/DIMO-Network/shared"
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/tester"
 	"github.com/rs/zerolog"
@@ -66,8 +66,8 @@ func TestPrivacyV2(t *testing.T) {
 						"userDeviceId": " 2fbaXmHpdQiKyAH6o5hHTCYwU0U",
 					},
 				},
+				VehicleTokenID: uint32(tokenID),
 			},
-			TokenID: uint64(tokenID),
 		}
 
 		gt.Consume(string(fg.StatusInput), vehicleTokenID, &statusV2)
@@ -141,8 +141,8 @@ func TestPrivacyV2(t *testing.T) {
 						},
 					},
 				},
+				VehicleTokenID: uint32(tokenID),
 			},
-			TokenID: uint64(tokenID),
 		}
 
 		gt.Consume(string(fg.StatusInput), vehicleTokenID, &statusV2)
@@ -258,8 +258,8 @@ func TestPrivacyV2(t *testing.T) {
 						},
 					},
 				},
+				VehicleTokenID: uint32(tokenID),
 			},
-			TokenID: uint64(tokenID),
 		}
 
 		gt.Consume(string(fg.StatusInput), vehicleTokenID, &statusV2)
@@ -282,7 +282,7 @@ func TestPrivacyV2(t *testing.T) {
 			)
 		}
 
-		if uint64(tokenID) != event.TokenID {
+		if uint32(tokenID) != event.VehicleTokenID {
 			t.Errorf("Expected TokenID to be %d", tokenID)
 		}
 

--- a/internal/processors/status.go
+++ b/internal/processors/status.go
@@ -3,6 +3,7 @@ package processors
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/DIMO-Network/shared"
 )
 
@@ -72,7 +73,6 @@ func (d *StatusData) UnmarshalJSON(data []byte) error {
 
 type StatusEventV2[A any] struct {
 	shared.CloudEvent[A]
-	TokenID   uint64 `json:"vehicleTokenId"`
 	Signature string `json:"signature"`
 }
 


### PR DESCRIPTION
1. Update the shared lib so we do not strip vehicleTokenId on v1 messages.
2. We no longer need to explicitly pass though vehicleTokenId on v2 messages.